### PR TITLE
Remove extra rename/copy when user gives -of

### DIFF
--- a/rund_test.d
+++ b/rund_test.d
@@ -617,7 +617,7 @@ void runTests(string rundApp, string compiler, string model)
         execPass(rundArgs ~ ["--build-only", "--force", "-lib", "-of=" ~ altLibName, srcName]);
         assert(exists(altLibName));
 
-        auto helloExe = binDir.buildPath("hello");
+        auto helloExe = binDir.buildPath("hello") ~ binExt;
         execPass(rundArgs ~ ["--force", "-of=" ~ helloExe, testFiles.hello])
             .enforceCanFind("Hello!");
         assert(exists(helloExe));

--- a/src/rund/chatty.d
+++ b/src/rund/chatty.d
@@ -86,7 +86,7 @@ struct Chatty
             enum skipOnDryRun = false;
         }
 
-        static if (fileFunc.among("copy", "moveFile", "rename"))
+        static if (fileFunc.among("copy", "rename"))
         {
             enum logReturn = false;
             yap!(file, line)(fileFunc, " ", args[0], " ", args[1]);

--- a/src/rund/file.d
+++ b/src/rund/file.d
@@ -70,20 +70,6 @@ FileAttributes getFileAttributes(const(char)[] name)
     else static assert(0);
 }
 
-void moveFile(const(char)[] from, const(char)[] to)
-{
-    static import std.file;
-    try
-    {
-        std.file.rename(from, to);
-    }
-    catch (std.file.FileException)
-    {
-        std.file.copy(from, to);
-        std.file.remove(from);
-    }
-}
-
 string which(string path)
 {
     import std.algorithm : findAmong, splitter;


### PR DESCRIPTION
NOTE: this PR removes the need for moveFile because now all renames should occur in the same directory.