### PR TITLE
Add the --od option (main output file directory)

### DIFF
--- a/make.d
+++ b/make.d
@@ -272,7 +272,7 @@ private void run(string command)
 
 void test(const(char)[] rundExe, string[] extraArgs)
 {
-    run(format("%s -g -debug %s %s %s%s",
+    run(format("%s %s %s %s%s",
         formatQuotedIfSpaces(rundExe),
         formatQuotedIfSpaces("-I" ~ getFilename("src")),
         getFilename("rund_test.d"),

--- a/src/rund/chatty.d
+++ b/src/rund/chatty.d
@@ -19,7 +19,7 @@ private void yapfWithLoc(T...)(string file, size_t line, string format, T args)
     if(chatty)
     {
         debug stderr.writef("%s(%s) ", file, line);
-        writefln(format, args);
+        stderr.writefln(format, args);
     }
 }
 pragma(inline) void yap(string file = __FILE__, size_t line = __LINE__, T...)(auto ref T stuff)


### PR DESCRIPTION
I also added a test to make sure that option `--od` uses the "buildWitness".  I need to make sure we also test that the buildWitness is used with all combinations of `-o*` switches.